### PR TITLE
Fix default state of the 'ask' to be false 

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -86,7 +86,7 @@ impl<'a> Validator<'a> {
         };
         redraw(&lines);
 
-        let mut response = true;
+        let mut response = false;
 
         loop {
             match get_event(&mut buttons) {


### PR DESCRIPTION
By default, UI highlights 'Cancel', but if the user presses both buttons, the returned value is 'true', which does not match the state of UI.
